### PR TITLE
Markdown links are case-sensitive

### DIFF
--- a/pages/presentations/docs/presentation-formats.md
+++ b/pages/presentations/docs/presentation-formats.md
@@ -4,9 +4,9 @@ path: presentations/presentation-formats
 ---
 
 We support the following presentation formats:
-- [Keynote](#keynote)
-- [Google Slides](#google-slides)
-- [Figma](#figma)
+- [Keynote](#Keynote)
+- [Google Slides](#Google-Slides)
+- [Figma](#Figma)
 
 😕 **Having trouble?** Message us in [#design-systems](https://github.slack.com/messages/C0ZCGGGJ2) for assistance.
 


### PR DESCRIPTION
TIL! So this changes the markdown links in the table of contents so they work =]