### PR TITLE
Updated keynote theme and added doc images

### DIFF
--- a/pages/presentations/docs/assets.md
+++ b/pages/presentations/docs/assets.md
@@ -7,17 +7,19 @@ This document contains a running list of all of the assets and templates used fo
 
 ## Icons
 ### Octicons
+![Octicons](https://user-images.githubusercontent.com/10384315/57805935-e6fd7e00-7712-11e9-873a-98187da7a06c.png)
 Octicons are the standard icon set used on GitHub.
 [Web](https://octicons.github.com/) | [GitHub](https://github.com/primer/octicons) | [Figma](https://www.figma.com/file/FP7lqd1V00LUaT5zvdklkkZr/Octicons)
 
-### Marketing icons
+### GitHub Marketing icons
+![GitHub Marketing icons](https://user-images.githubusercontent.com/10384315/57806011-13b19580-7713-11e9-8e27-7d481b5314cc.png)
 The GitHub Marketing icons were created by the Creative team for use in our web, email, and other digital marketing collateral. Choose from GitHub's brand blue color, or a monochrome white on dark.
 [Web](https://ghicons.github.com/) | [GitHub](https://github.com/github/icons) | [Figma](https://www.figma.com/file/mI7o0RNCbWFhckw2svxKsm/GitHub-Updated-icons-Expanded?node-id=56%3A56) | [Keynote & PowerPoint](https://drive.google.com/open?id=1SgEAakP98krI0TxzXc_B0AAGu4AxI2G5)
 
 ## Presentation Templates
-### Keynote
+### <img width="24" alt="icon-keynote" src="https://user-images.githubusercontent.com/10384315/57806478-12349d00-7714-11e9-9639-20f303945cdc.png" /> Keynote
 The keynote template is available for GitHub employees on [Google Drive](https://drive.google.com/open?id=1Wp3NyCYM-FsU-4MKSbPcBgIsWVgvUQy0).
-### PowerPoint
+### <img width="24" alt="icon-powerpoint" src="https://user-images.githubusercontent.com/10384315/57806529-2b3d4e00-7714-11e9-9e71-fe864c2059a6.png" /> PowerPoint
 The powerpoint template is available for GitHub employees on [Google Drive](https://drive.google.com/open?id=1QKiEbruGhWAY85NsEuTIEccDlAiz9qbD).
-### Google Slides
+### <img width="24" alt="icon-slides" src="https://user-images.githubusercontent.com/10384315/57806530-2b3d4e00-7714-11e9-83b8-65ac6c95c0d0.png" /> Google Slides
 The Google slides template is available as a custom theme within the [template gallery](https://docs.google.com/presentation/u/0/?tgif=d&ftv=1).

--- a/pages/presentations/docs/presentation-formats.md
+++ b/pages/presentations/docs/presentation-formats.md
@@ -9,7 +9,7 @@ We support the following presentation formats:
 - [Google Slides](#Google-Slides)
 - [Figma](#Figma)
 
-### Keynote
+### <img width="24" alt="icon-keynote" src="https://user-images.githubusercontent.com/10384315/57806478-12349d00-7714-11e9-9639-20f303945cdc.png" /> Keynote
 Keynote templates are available for download to the members of the GitHub organization on [Google Drive](https://drive.google.com/open?id=1Wp3NyCYM-FsU-4MKSbPcBgIsWVgvUQy0).
 
 ![The Keynote files](https://user-images.githubusercontent.com/10384315/56326001-35762780-6129-11e9-915d-949763cb1186.png)
@@ -27,7 +27,7 @@ To install, open the theme file (`.kth`) in Keynote and click **Add to Theme Cho
 
 You will now have the theme available any time you open Keynote.
 
-### PowerPoint
+### <img width="24" alt="icon-powerpoint" src="https://user-images.githubusercontent.com/10384315/57806529-2b3d4e00-7714-11e9-9e71-fe864c2059a6.png" /> PowerPoint
 PowerPoint templates are available for download to the members of the GitHub organization on [Google Drive](https://drive.google.com/open?id=1QKiEbruGhWAY85NsEuTIEccDlAiz9qbD).
 
 #### Creating a new presentation
@@ -49,13 +49,13 @@ The main difference is that a `.potx` is a template file which will create a new
 | At the bottom, click on **Browse for Themes**. | ![Browse for Themes](https://user-images.githubusercontent.com/10384315/57048344-6a55a480-6c28-11e9-8f61-70ed23816606.png) |
 | Navigate to your `github-presentation-system-powerpoint` folder | ![Navigate to your file](https://user-images.githubusercontent.com/10384315/57048569-58283600-6c29-11e9-890c-f75694b67d5a.png) |
 
-### Google Slides
+### <img width="24" alt="icon-slides" src="https://user-images.githubusercontent.com/10384315/57806530-2b3d4e00-7714-11e9-83b8-65ac6c95c0d0.png" /> Google Slides
 
 The GitHub Presentation Template is available for use in the Google Slides template gallery.
 
 ![slides-template](https://user-images.githubusercontent.com/10384315/54726109-ce1b8680-4b2e-11e9-8746-4b83dae92a16.gif)
 
-### Figma
+### <img width="24" alt="icon-figma" src="https://user-images.githubusercontent.com/10384315/57806800-bddded00-7714-11e9-98fe-f3021839cfde.png" /> Figma
 The GitHub presentation theme is available as a Figma library for members of the GitHub organization.
 
 To use, enable the Presentation - Technology Theme v1 in the Team libraries.

--- a/pages/presentations/docs/versioning.md
+++ b/pages/presentations/docs/versioning.md
@@ -6,6 +6,12 @@ path: presentations/versioning
 Versioning for the Primer presentation system will be logged by date. All updates will be kept in a changelog located in both the presenters notes of a changelog slide and on the Primer presentations site.
 
 ## Changelog
+### May 15, 2019
+- Added icon set thumbnails and format icons to docs for clearer context
+
+Keynote:
+- Fixed `Missing font...` bug.
+
 ### May 1, 2019
 - Microsoft Office users rejoice! The presentation design system now includes source files for PowerPoint. Inside you will now find the following:
   - PowerPoint theme (.thmx)
@@ -14,7 +20,7 @@ Versioning for the Primer presentation system will be logged by date. All update
   - GitHub Icons for PowerPoint
   - Logo sheet for PowerPoint
 - Separated keynote, powerpoint, and icon files into separate .zip files
-- Added documentation for powerpoint and updated asset links to reflect changes 
+- Added documentation for powerpoint and updated asset links to reflect changes
 
 Keynote:
 - Added `Section Title - Blue` layout


### PR DESCRIPTION
This PR fixes the issues brought up in #28 and #27.

- Assets now include thumbnails for different icon sets.
- Renamed Marketing Icons -> GitHub Marketing Icons for better context
- Keynote theme no longer has missing font issues.

