### PR TITLE
Fix root route with no slash

### DIFF
--- a/now.json
+++ b/now.json
@@ -10,6 +10,7 @@
     }
   ],
   "routes": [
+    {"src": "/presentations", "dest": "/"},
     {"src": "/presentations(/.*)?", "dest": "$1"},
     {
       "src": "/",


### PR DESCRIPTION
Same as https://github.com/primer/design/pull/92

Updates `/presentations` to serve `/presentations/'