### PR TITLE
Auto-bump: @primer/gatsby-theme-doctocat@0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "^0.16.8",
+    "@primer/gatsby-theme-doctocat": "^0.19.1",
     "eslint": "4.19.1",
     "eslint-plugin-github": "1.0.0",
     "eslint-plugin-prettier": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,10 +1184,10 @@
     style-value-types "^3.1.7"
     tslib "^1.10.0"
 
-"@primer/components@^15.1.1":
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/components/-/components-15.3.0.tgz#dc2ca5bbe21e39d002fe672633b30a94d913c0e3"
-  integrity sha512-Y1aOhowuAYU4fpq1++g0Kba6vzUPj2tcTLWXe7UFJVWETSX9tkUyaFt6FDA+qsdU9QlPONgbSM4evsG8xKokpw==
+"@primer/components@^16.1.0":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@primer/components/-/components-16.3.0.tgz#c623424cc57edcfc5007284970ffbc0fd72f7dbf"
+  integrity sha512-oydKIzcDCtIDjbGEUCLuxW94sDfBFbKRne/I4DlnYYnv6DGxpL1hE3zLoKp3+f5ycpsFSAckXJBafIhimQljpQ==
   dependencies:
     "@primer/octicons-react" "^9.2.0"
     "@reach/dialog" "0.3.0"
@@ -1208,16 +1208,16 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@^0.16.8":
-  version "0.16.10"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.16.10.tgz#9798bca7b08b548e8b9bd62f8ca7a8be9003d5a5"
-  integrity sha512-173EeoIEwf1cAO3te4XDYg+kjQwLhtlOU2LAHty8T7Hb8hjOLysBPO3rmmtz583+eWhASA0GBb6cvR5S6/OQHg==
+"@primer/gatsby-theme-doctocat@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.19.1.tgz#056842fac3ece68491809e012c1fb8958b85efef"
+  integrity sha512-c3Lh79VKgDrQHWHBMGpgo/ogTS5FvEbrVrp2EFMfUM/DBCu5cXZhe6LfCcz/vr7O+ZPlRpHZFpXSeNShWrU9zQ==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
     "@mdx-js/mdx" "^1.0.21"
     "@mdx-js/react" "^1.0.21"
-    "@primer/components" "^15.1.1"
+    "@primer/components" "^16.1.0"
     "@primer/octicons-react" "^9.1.1"
     "@styled-system/theme-get" "^5.0.12"
     "@testing-library/jest-dom" "^4.1.0"
@@ -1252,7 +1252,7 @@
     prism-react-renderer "^0.1.7"
     react-addons-text-content "^0.0.4"
     react-element-to-jsx-string "^14.0.3"
-    react-focus-on "^3.0.6"
+    react-focus-on "^3.3.0"
     react-frame-component "^4.1.1"
     react-helmet "^5.2.1"
     react-live "^2.1.2"
@@ -11421,7 +11421,7 @@ react-focus-lock@^2.1.0, react-focus-lock@^2.2.1:
     use-callback-ref "^1.2.1"
     use-sidecar "^1.0.1"
 
-react-focus-on@^3.0.6:
+react-focus-on@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.3.0.tgz#f6b3630ef61cdb26018b4d47cafca726b0d7aaa5"
   integrity sha512-Qbgg2A0YwVuY2g3l5yazzTlHrOC6L4a1P2advANQmdXo7xeAokV5RCtk4sqT0ZoW81LU8IAJCsYzqIdXBBclGg==


### PR DESCRIPTION
Auto-upgrade of @primer/gatsby-theme-doctocat to 0.19.1 via multibump.