### PR TITLE
Auto-bump: @primer/gatsby-theme-doctocat@1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "^0.25.2",
+    "@primer/gatsby-theme-doctocat": "^1.1.0",
     "@primer/octicons-react": "^11.0.0",
     "eslint": "4.19.1",
     "eslint-plugin-github": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,16 +1616,17 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@^0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.25.2.tgz#f0d871ac204902b153e2c9a1926390e54aa2419b"
-  integrity sha512-Hihiz2yTT4tEOUurLBRr8SlHNP9jPupBoMXbc/IC7HoxwyNONKpl8wOojgJvswAiHx1Gd4knTEzD6ZbC3KGtyw==
+"@primer/gatsby-theme-doctocat@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-1.1.0.tgz#f9edcbe796f2da10158a238f3dd9ed05c6b85634"
+  integrity sha512-mWxmIGSYJZGPnWBEeB+EnOriL/p+xh2XWTBhuJrX8Q4x6Kx9L46KZIYCZt+5cHKTNSzGsU645bBkyS4vItZCrQ==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
     "@mdx-js/mdx" "^1.0.21"
     "@mdx-js/react" "^1.0.21"
     "@primer/components" "^20.0.0"
+    "@primer/octicons-react" "^11.0.0"
     "@styled-system/theme-get" "^5.0.12"
     "@testing-library/jest-dom" "^4.1.0"
     "@testing-library/react" "^9.1.3"


### PR DESCRIPTION
Auto-upgrade of `@primer/gatsby-theme-doctocat` to `1.1.0` via multibump.