### PR TITLE
Release v2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Primer Presentation System
+
+`Current version: v2020`
+
 ## Documentation
 Our documentation site currently lives at [https://primer.style/presentations/](https://primer.style/presentations/). You'll be able to find the information listed in this README as well as detailed docs for presentation guidelines, presentation formats, and assets.
 ## Installation

--- a/content/assets/template-files.mdx
+++ b/content/assets/template-files.mdx
@@ -4,11 +4,11 @@ title: Template files
 
 ## Keynote
 
-The [Keynote](presentation-formats#object-Object-Keynote) template is available for GitHub employees on [Google Drive](https://drive.google.com/open?id=1Wp3NyCYM-FsU-4MKSbPcBgIsWVgvUQy0).
+The [Keynote](presentation-formats#object-Object-Keynote) template is available for GitHub employees on [Google Drive](https://drive.google.com/file/d/1rneeYAzbt7yZrqMjkzBTNKxkNH8h24ok).
 
 ## PowerPoint
 
-The [PowerPoint](presentation-formats#object-Object-PowerPoint) template is available for GitHub employees on [Google Drive](https://drive.google.com/open?id=1QKiEbruGhWAY85NsEuTIEccDlAiz9qbD).
+The [PowerPoint](presentation-formats#object-Object-PowerPoint) template is available for GitHub employees on [Google Drive](https://drive.google.com/file/d/1mnxk1oVKw1-RtAy5iQpXPSNbxBvbrKox).
 
 ## Google Slides
 

--- a/content/presentation-formats/keynote.mdx
+++ b/content/presentation-formats/keynote.mdx
@@ -2,13 +2,13 @@
 title: Keynote
 ---
 
-Keynote templates are available for download to the members of the GitHub organization on [Google Drive](https://drive.google.com/open?id=1Wp3NyCYM-FsU-4MKSbPcBgIsWVgvUQy0).
+Keynote templates are available for download to the members of the GitHub organization on [Google Drive](https://drive.google.com/file/d/1rneeYAzbt7yZrqMjkzBTNKxkNH8h24ok/view?usp=sharing).
 
 ![The Keynote files](https://user-images.githubusercontent.com/10384315/56326001-35762780-6129-11e9-915d-949763cb1186.png)
 
 ### Creating a new presentation
 
-A new presentation can be created by opening `github-presentation-template.key` or `github-presentation-theme.kth`.
+A new presentation can be created by opening `github-presentation-template-v2020.key` or `github-presentation-theme-v2020.kth`.
 
 <Note variant="warning">
 If you just open the regular keynote file (`.key`), you will need to duplicate this for your own presentation if you do not want to override the template for later use. It is recommended that for your first presentation you open the theme file (`.kth`) and add the theme to your Keynote to use for future use.

--- a/content/presentation-formats/powerpoint.mdx
+++ b/content/presentation-formats/powerpoint.mdx
@@ -2,7 +2,7 @@
 title: PowerPoint
 ---
 
-PowerPoint templates are available for download to the members of the GitHub organization on [Google Drive](https://drive.google.com/open?id=1QKiEbruGhWAY85NsEuTIEccDlAiz9qbD).
+PowerPoint templates are available for download to the members of the GitHub organization on [Google Drive](https://drive.google.com/file/d/1mnxk1oVKw1-RtAy5iQpXPSNbxBvbrKox).
 
 ### Creating a new presentation
 
@@ -10,9 +10,10 @@ A new presentation can be created using either the `.potx` file or the `.pptx` f
 
 #### .potx vs .pptx: What's the difference?
 
-First of all, both the `.potx` and the `.pptx` will open and create a new document.
+Both the `.potx` and the `.pptx` will open and create a new document.
 
-The main difference is that a `.potx` is a template file which will create a new presentation with the presentation system theming (slides, colors, type) already in place. The `.pptx` on the other hand will just open like a normal file and you will have to **Save a Copy** or rename for your presentation.
+- A `.potx` is a template file which will create a new presentation with the presentation system theming (slides, colors, type) already in place.
+- A `.pptx` will open like a normal file. When using select **Save a Copy** or rename the file specific to the presentation.
 
 **Tip:** The design systems team recommends using the template(`.potx`) file as this will start a fresh document with everything loaded right away. 😄
 
@@ -31,4 +32,3 @@ The main difference is that a `.potx` is a template file which will create a new
 😕 **Having trouble?** Message us in [#design-systems](https://github.slack.com/messages/C0ZCGGGJ2) for assistance.
 
 </Note>
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "^1.3.0",
+    "@primer/gatsby-theme-doctocat": "^1.6.0",
     "@primer/octicons-react": "^11.0.0",
     "eslint": "4.19.1",
     "eslint-plugin-github": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,10 +1533,10 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-1.3.0.tgz#6a653176f34af41dd17393222d9545c282bac6ca"
-  integrity sha512-tlYEbTqJTxGj/AI26EbHMKpUK+qHUhpBhzmzTCHU9aXiOLXpk+M77F0MEifFk07bkc//xaaZvy+VtlA936XpHg==
+"@primer/gatsby-theme-doctocat@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-1.6.0.tgz#b80831b17ad654b34e9d0379b42bb7fd833fac72"
+  integrity sha512-E/GXYk07VhWt0l18v30xCu+NlDszvSdTs56dKFuH+L8JlV2V2efvl88kKm2INqlM9PTP/bFQ9jeyKSC1YDHNiQ==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
@@ -1574,7 +1574,8 @@
     pkg-up "^3.1.0"
     pluralize "^8.0.0"
     preval.macro "^3.0.0"
-    prism-react-renderer "^0.1.7"
+    prism-react-renderer "^1.2.0"
+    prismjs "^1.22.0"
     react-addons-text-content "^0.0.4"
     react-element-to-jsx-string "^14.0.3"
     react-focus-on "^3.3.0"
@@ -4070,6 +4071,15 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
+clipboard@^2.0.0:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.7.tgz#da927f817b1859426df39212ac81feb07dbaeadc"
+  integrity sha512-8M8WEZcIvs0hgOma+wAPkrUxpv0PMY1L6VsAJh/2DOKARIMpyWe6ZLcEoe1qktl6/ced5ceYHs+oGedSbgZ3sg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 clipboardy@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
@@ -5060,6 +5070,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -7419,6 +7434,13 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 got@8.3.2:
   version "8.3.2"
@@ -11929,15 +11951,17 @@ preval.macro@^3.0.0:
   dependencies:
     babel-plugin-preval "^3.0.0"
 
-prism-react-renderer@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-0.1.7.tgz#dc273d0cb6e4a498ba0775094e9a8b01a3ad2eaa"
-  integrity sha512-EhnM0sYfLK103ASK0ViSv0rta//ZGB0dBA9TiFyOvA+zOj5peLmGEG01sLEDwl9sMe+gSqncInafBe1VFTCMvA==
+prism-react-renderer@^1.0.1, prism-react-renderer@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.0.tgz#5ad4f90c3e447069426c8a53a0eafde60909cdf4"
+  integrity sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==
 
-prism-react-renderer@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
-  integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
+prismjs@^1.22.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
+  optionalDependencies:
+    clipboard "^2.0.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -13253,6 +13277,11 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
+
 selfsigned@^1.10.7:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
@@ -14525,6 +14554,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 title-case@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
This is the release branch for v2020 of Primer Presentations:

- [x] #71 Bump @primer/gatsby-theme-doctocat from 1.3.0 to 1.6.0
- [x] #72 update links to presentation files