### PR TITLE
Set defaultBranch settings and fix broken link in built pages.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,12 @@ module.exports = {
   },
   pathPrefix: '/presentations',
   plugins: [
-    '@primer/gatsby-theme-doctocat',
+    {
+      resolve: '@primer/gatsby-theme-doctocat',
+      options: {
+        defaultBranch: 'main'
+      }
+    },
     {
       resolve: 'gatsby-plugin-alias-imports',
       options: {


### PR DESCRIPTION
Since default branch is set to `master` in doctocat, the links shown `Edit this page on GitHub` in built page are broken.

eg. https://github.com/primer/presentations/edit/master/content/presentation-formats/google-slides.mdx

ref: https://primer.style/doctocat/usage/customization#default-branch