### PR TITLE
Fix link to color system page

### DIFF
--- a/content/design-guidelines/color-usage.mdx
+++ b/content/design-guidelines/color-usage.mdx
@@ -2,7 +2,7 @@
 title: Color usage
 ---
 
-Primer Presentations uses the same [color system](https://primer.style/css/support/color-system) created for our product. Color pairings for text, background, and highlighted/important information have been selected for optimal contrast. Refer to the following table for color pairings.
+Primer Presentations uses the same [color system](https://primer.style/design/foundations/color) created for our product. Color pairings for text, background, and highlighted/important information have been selected for optimal contrast. Refer to the following table for color pairings.
 
 | Background |   Text   | Highlight  |   Footer   |
 | :--------: | :------: | :--------: | :--------: |


### PR DESCRIPTION
I realized that this link was no longer working. I believe the new URL to correspond to the page that was linked to previously.