### PR TITLE
Fixed outdated slack url

### DIFF
--- a/content/presentation-formats/figma.mdx
+++ b/content/presentation-formats/figma.mdx
@@ -6,7 +6,7 @@ The GitHub presentation template is available as a Figma library for members of 
 
 ### How to use
 
-1. Open `GitHub Presentation Template` located in the `Presentations` project in the Primer team in Figma
+1. Open [`GitHub Presentation Template`](https://www.figma.com/file/0mXCPvPvDgbtiMEIa5Z8DSh9/GitHub-presentation-template) located in the [`Presentations`](https://www.figma.com/files/project/5764839) project in the Primer team in Figma
 
 <img
   width="656"
@@ -31,7 +31,7 @@ For more information on how to duplicate files in Figma, please refer to [Figma'
 <Note>
 
 
-😕 **Having trouble?** Message us in [#design-systems](https://github.slack.com/messages/C0ZCGGGJ2) for assistance.
+😕 **Having trouble?** Message us in [#primer-design](https://github.slack.com/archives/CPA865D9S) for assistance.
 
 </Note>
 


### PR DESCRIPTION
## Changes:
- #design-systems → #primer-design
- added url for presentation file and figam folder